### PR TITLE
Update README

### DIFF
--- a/README
+++ b/README
@@ -4,7 +4,7 @@ Let's say you have a users table in your db with the following columns : id, pse
 
 A call to reverse_scaffold :
 
-ruby script/reverse_scaffold users user 
+ruby script/reverse_scaffold users User 
 
 Will execute : 
 


### PR DESCRIPTION
Model name must be uppercase.

---

script/reverse_scaffold.rb:135:in `eval': (eval):1: class/module name must be CONSTANT (SyntaxError)
## class ::user < ActiveRecord::Base; set_table_name 'users' end
